### PR TITLE
Allows scheme and domain to match ignoring case

### DIFF
--- a/lib/onelogin/ruby-saml/response.rb
+++ b/lib/onelogin/ruby-saml/response.rb
@@ -528,12 +528,38 @@ module OneLogin
       def validate_destination
         return true if destination.nil? || destination.empty? || settings.assertion_consumer_service_url.nil? || settings.assertion_consumer_service_url.empty?
 
-        unless destination == settings.assertion_consumer_service_url
+        unless uri_match?
           error_msg = "The response was received at #{destination} instead of #{settings.assertion_consumer_service_url}"
           return append_error(error_msg)
         end
 
         true
+      end
+
+      # Compare the destination and the ACS url.  The scheme and the FQDN should be matched case insensitive, while
+      # the path should be case sensitive. If Rails can't parse out a scheme and a host, default to the
+      # original match.
+      # @return [Boolean]
+      def uri_match?
+        dest_uri = URI.parse(destination)
+        acs_uri = URI.parse(settings.assertion_consumer_service_url)
+
+        if dest_uri.scheme.nil? || acs_uri.scheme.nil? || dest_uri.host.nil? || acs_uri.host.nil?
+          raise URI::InvalidURIError
+        else
+          dest_uri.scheme.downcase == acs_uri.scheme.downcase &&
+            dest_uri.host.downcase == acs_uri.host.downcase &&
+            dest_uri.path == acs_uri.path &&
+            dest_uri.query == acs_uri.query
+        end
+      rescue URI::InvalidURIError
+        original_uri_match?
+      end
+
+      # If Rails' URI.parse can't match to valid URL, default back to the original matching service.
+      # @return [Boolean]
+      def original_uri_match?
+        destination == settings.assertion_consumer_service_url
       end
 
       # Validates the Conditions. (If the response was initialized with the :skip_conditions option, this validation is skipped,

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -439,6 +439,34 @@ class RubySamlTest < Minitest::Test
         assert !response.send(:validate_destination)
         assert_includes response.errors, "The response was received at #{response.destination} instead of #{response.settings.assertion_consumer_service_url}"
       end
+
+      it "returns true on a case insensitive match on the domain" do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'http://APP.muDa.no/sso/consume'
+        assert response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_empty response_valid_signed_without_x509certificate.errors
+      end
+
+      it "returns true on a case insensitive match on the scheme" do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'HTTP://app.muda.no/sso/consume'
+        assert response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_empty response_valid_signed_without_x509certificate.errors
+      end
+
+      it "returns false on a case insenstive match on the path" do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'http://app.muda.no/SSO/consume'
+        assert !response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_includes response_valid_signed_without_x509certificate.errors, "The response was received at #{response_valid_signed_without_x509certificate.destination} instead of #{response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url}"
+      end
+
+      it "returns true if it can't parse out a full URI." do
+        response_valid_signed_without_x509certificate.settings = settings
+        response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url = 'presenter'
+        assert !response_valid_signed_without_x509certificate.send(:validate_destination)
+        assert_includes response_valid_signed_without_x509certificate.errors, "The response was received at #{response_valid_signed_without_x509certificate.destination} instead of #{response_valid_signed_without_x509certificate.settings.assertion_consumer_service_url}"
+      end
     end
 
     describe "#validate_issuer" do


### PR DESCRIPTION
 - Per RFC4343, the domain name portion of a URI should be considered case-insensitive.
 - Per RFC3986, the scheme portion of a URI should be considered case-insenstive.
 - Some SSO providers allow users to enter their own subdomain, which many may do with capital letters (such as in the case of an acronym).
 - The destination match should take this in to consideration when matching the destination URI to the ACS URI, if these are proper URIs.
 - The match should default to the original case when either of the values are not proper URIs.